### PR TITLE
Update API key expiration time to 365 days

### DIFF
--- a/amplify/backend/api/christiansresume/cli-inputs.json
+++ b/amplify/backend/api/christiansresume/cli-inputs.json
@@ -5,7 +5,7 @@
     "serviceName": "AppSync",
     "defaultAuthType": {
       "mode": "API_KEY",
-      "expirationTime": 7
+      "expirationTime": 365
     }
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended API authentication key validity period from 7 to 365 days.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->